### PR TITLE
Implement TX rate limiting

### DIFF
--- a/ixgbe-4.1.5/src/ixgbe_ethtool.c
+++ b/ixgbe-4.1.5/src/ixgbe_ethtool.c
@@ -836,6 +836,87 @@ static void ixgbe_get_regs(struct net_device *netdev, struct ethtool_regs *regs,
 
 }
 
+static u32 ixgbe_rss_indir_size(struct net_device *netdev)
+{
+	/*struct ixgbe_adapter *adapter = netdev_priv(netdev);*/
+
+	return IXGBE_RETA_SIZE;
+}
+
+static int ixgbe_get_rxfh(struct net_device *netdev, u32 *indir, u8 *key,
+			  u8 *hfunc)
+{
+	struct ixgbe_adapter *adapter = netdev_priv(netdev);
+	struct ixgbe_hw *hw = &adapter->hw;
+	int i, j, d, indices_multi;
+	u32 reta = 0;
+
+	/* Read out the redirection table as follows:
+	 * 82598: 128 (8 bit wide) entries containing pair of 4 bit RSS indices
+	 * 82599/X540: 128 (8 bit wide) entries containing 4 bit RSS index
+	 */
+	if (adapter->hw.mac.type == ixgbe_mac_82598EB)
+	indices_multi = 0x11;
+	else
+	indices_multi = 0x1;
+
+	/* Read out the redirection table */
+	for (i = 0, j = 0; i < IXGBE_RETA_SIZE / 4; i++) {
+		reta = IXGBE_READ_REG(hw, IXGBE_RETA(i));
+		j+=4;
+		for (d = 1; d < 5; d++) {
+			indir[j - d] = (reta & 0xFF) / indices_multi;
+			reta = reta >> 8;
+		}
+	}
+	return 0;
+}
+
+static int ixgbe_set_rxfh(struct net_device *netdev, const u32 *indir,
+                          const u8 *key, const u8 hfunc)
+{
+	struct ixgbe_adapter *adapter = netdev_priv(netdev);
+	struct ixgbe_hw *hw = &adapter->hw;
+	u32 reta = 0;
+	int i, indices_multi;
+	u32 num_queues;
+
+	if (hfunc)
+		return -EINVAL;
+
+	num_queues = adapter->num_rx_queues;
+
+	/*
+	 * Allow at least 2 queues w/ SR-IOV.
+	 */
+	if ((adapter->flags & IXGBE_FLAG_SRIOV_ENABLED) && (num_queues < 2))
+		num_queues = 2;
+
+	/* Verify user input. */
+	for (i = 0; i < IXGBE_RETA_SIZE; i++)
+		if (indir[i] >= num_queues)
+			return -EINVAL;
+
+	/* Fill out the redirection table as follows:
+	 * 82598: 128 (8 bit wide) entries containing pair of 4 bit RSS indices
+	 * 82599/X540: 128 (8 bit wide) entries containing 4 bit RSS index
+	 */
+	if (adapter->hw.mac.type == ixgbe_mac_82598EB)
+		indices_multi = 0x11;
+	else
+		indices_multi = 0x1;
+
+	/* Fill out the redirection table */
+	for (i = 0; i < IXGBE_RETA_SIZE; i++) {
+		reta = (reta << 8) | (indir[i] * indices_multi);
+		if ((i & 3) == 3) {
+			if (i < 128)
+				IXGBE_WRITE_REG(hw, IXGBE_RETA(i >> 2), reta);
+		}
+	}
+	return 0;
+}
+
 static int ixgbe_get_eeprom_len(struct net_device *netdev)
 {
 	struct ixgbe_adapter *adapter = netdev_priv(netdev);
@@ -3632,6 +3713,9 @@ static struct ethtool_ops ixgbe_ethtool_ops = {
 	.nway_reset		= ixgbe_nway_reset,
 	.get_link		= ethtool_op_get_link,
 	.get_eeprom_len		= ixgbe_get_eeprom_len,
+	.get_rxfh_indir_size	= ixgbe_rss_indir_size,
+	.get_rxfh		= ixgbe_get_rxfh,
+	.set_rxfh		= ixgbe_set_rxfh,
 	.get_eeprom		= ixgbe_get_eeprom,
 	.set_eeprom		= ixgbe_set_eeprom,
 	.get_ringparam		= ixgbe_get_ringparam,

--- a/ixgbe-4.1.5/src/ixgbe_sriov.c
+++ b/ixgbe-4.1.5/src/ixgbe_sriov.c
@@ -1248,7 +1248,7 @@ out:
 	return err;
 }
 
-static int ixgbe_link_mbps(struct ixgbe_adapter *adapter)
+int ixgbe_link_mbps(struct ixgbe_adapter *adapter)
 {
 	switch (adapter->link_speed) {
 	case IXGBE_LINK_SPEED_100_FULL:

--- a/ixgbe-4.1.5/src/ixgbe_sriov.h
+++ b/ixgbe-4.1.5/src/ixgbe_sriov.h
@@ -33,6 +33,7 @@
 
 void ixgbe_restore_vf_multicasts(struct ixgbe_adapter *adapter);
 int ixgbe_set_vf_vlan(struct ixgbe_adapter *adapter, int add, int vid, u32 vf);
+int ixgbe_link_mbps(struct ixgbe_adapter *adapter);
 void ixgbe_set_vmolr(struct ixgbe_hw *hw, u32 vf, bool aupe);
 void ixgbe_msg_task(struct ixgbe_adapter *adapter);
 int ixgbe_set_vf_mac(struct ixgbe_adapter *adapter,

--- a/ixgbe-4.1.5/src/ixgbe_type.h
+++ b/ixgbe-4.1.5/src/ixgbe_type.h
@@ -367,6 +367,7 @@ struct ixgbe_thermal_sensor_data {
 #define IXGBE_IMIREXT(_i)	(0x05AA0 + ((_i) * 4))  /* 8 of these (0-7) */
 #define IXGBE_IMIRVP		0x05AC0
 #define IXGBE_VMD_CTL		0x0581C
+#define IXGBE_RETA_SIZE         128
 #define IXGBE_RETA(_i)		(0x05C00 + ((_i) * 4))  /* 32 of these (0-31) */
 #define IXGBE_ERETA(_i)		(0x0EE80 + ((_i) * 4))  /* 96 of these (0-95) */
 #define IXGBE_RSSRK(_i)		(0x05C80 + ((_i) * 4))  /* 10 of these (0-9) */


### PR DESCRIPTION
Useful if you want to just send packets at the card and let the card itself smooth out the traffic at a given bitrate.
Adjustable per-queue, just do "echo <bitrate> > /sys/class/net/<interface>/queue/tx-<queue_number>/tx_maxrate" as a superuser.

Signed-off-by: Rostislav Pehlivanov <atomnuker@gmail.com>