### PR TITLE
Fix compilation

### DIFF
--- a/ixgbe-4.1.5/src/ixgbe_ptp.c
+++ b/ixgbe-4.1.5/src/ixgbe_ptp.c
@@ -24,6 +24,7 @@
 
 #include "ixgbe.h"
 #include <linux/ptp_classify.h>
+#include <linux/clocksource.h>
 
 /*
  * The 82599 and the X540 do not have true 64bit nanosecond scale


### PR DESCRIPTION
CLOCKSOURCE_MASK is defined in clocksource.h

Signed-off-by: Rostislav Pehlivanov <atomnuker@gmail.com>