### PR TITLE
Fix compilation with UTS_UBUNTU_RELEASE_ABI > 255

### DIFF
--- a/ixgbe-4.1.5/src/kcompat.h
+++ b/ixgbe-4.1.5/src/kcompat.h
@@ -753,7 +753,7 @@ struct _kc_ethtool_pauseparam {
 #define UBUNTU_VERSION_CODE (((LINUX_VERSION_CODE & ~0xFF) << 8) + (UTS_UBUNTU_RELEASE_ABI))
 
 #if UTS_UBUNTU_RELEASE_ABI > 255
-#error UTS_UBUNTU_RELEASE_ABI is too large...
+#warning UTS_UBUNTU_RELEASE_ABI is too large...
 #endif /* UTS_UBUNTU_RELEASE_ABI > 255 */
 
 #if ( LINUX_VERSION_CODE <= KERNEL_VERSION(3,0,0) )


### PR DESCRIPTION
No idea why this error is even there, everything works fine if it only
warns.
This is needed because Ubuntu kernels have an UTS_UBUNTU_RELEASE_ABI
larger than 255 when they are a pre-release version (e.g.
Linux 4.5.0-040500-generic from the willy repo).

Signed-off-by: Rostislav Pehlivanov <atomnuker@gmail.com>